### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/com/microsoft/dhalion/detectors/ExcessCpuDetector.java
+++ b/src/main/java/com/microsoft/dhalion/detectors/ExcessCpuDetector.java
@@ -29,7 +29,7 @@ public class ExcessCpuDetector extends ResourceAvailabilityDetector {
   public ExcessCpuDetector(PolicyConfig policyConfig) {
     super(policyConfig, CONFIG_KEY_PREFIX, SymptomName.EXCESS_CPU.text());
     thresholdRatio = (double) policyConfig.getConfig(CONFIG_KEY_PREFIX + THRESHOLD_RATIO_CONFIG_KEY, 2.0);
-    LOG.info("Detector created: " + this.toString());
+    LOG.info("Detector created: " + this);
   }
 
   @Override

--- a/src/main/java/com/microsoft/dhalion/detectors/ExcessMemoryDetector.java
+++ b/src/main/java/com/microsoft/dhalion/detectors/ExcessMemoryDetector.java
@@ -30,7 +30,7 @@ public class ExcessMemoryDetector extends ResourceAvailabilityDetector {
   public ExcessMemoryDetector(PolicyConfig policyConfig) {
     super(policyConfig, CONFIG_KEY_PREFIX, SymptomName.EXCESS_MEMORY.text());
     thresholdRatio = (double) policyConfig.getConfig(CONFIG_KEY_PREFIX + THRESHOLD_RATIO_CONFIG_KEY, 2.0);
-    LOG.info("Detector created: " + this.toString());
+    LOG.info("Detector created: " + this);
   }
 
   @Override

--- a/src/main/java/com/microsoft/dhalion/detectors/ResourceAvailabilityDetector.java
+++ b/src/main/java/com/microsoft/dhalion/detectors/ResourceAvailabilityDetector.java
@@ -80,7 +80,7 @@ public abstract class ResourceAvailabilityDetector extends Detector {
 
     Symptom symptom = new Symptom(symptomType, now, assignments);
     if (LOG.isLoggable(Level.FINE)) {
-      LOG.fine(String.format("Symptom (%s) created for %s", symptom, toString()));
+      LOG.fine(String.format("Symptom (%s) created for %s", symptom, ));
     }
     return Collections.singletonList(symptom);
   }

--- a/src/main/java/com/microsoft/dhalion/detectors/ScarceCpuDetector.java
+++ b/src/main/java/com/microsoft/dhalion/detectors/ScarceCpuDetector.java
@@ -29,7 +29,7 @@ public class ScarceCpuDetector extends ResourceAvailabilityDetector {
   public ScarceCpuDetector(PolicyConfig policyConfig) {
     super(policyConfig, CONFIG_KEY_PREFIX, SymptomName.SCARCE_CPU.text());
     thresholdRatio = (double) policyConfig.getConfig(CONFIG_KEY_PREFIX + THRESHOLD_RATIO_CONFIG_KEY, 1.5);
-    LOG.info("Detector created: " + this.toString());
+    LOG.info("Detector created: " + this);
   }
 
   @Override

--- a/src/main/java/com/microsoft/dhalion/detectors/ScarceMemoryDetector.java
+++ b/src/main/java/com/microsoft/dhalion/detectors/ScarceMemoryDetector.java
@@ -29,7 +29,7 @@ public class ScarceMemoryDetector extends ResourceAvailabilityDetector {
   public ScarceMemoryDetector(PolicyConfig policyConfig) {
     super(policyConfig, CONFIG_KEY_PREFIX, SymptomName.SCARCE_MEMORY.text());
     thresholdRatio = (double) policyConfig.getConfig(CONFIG_KEY_PREFIX + THRESHOLD_RATIO_CONFIG_KEY, 1.5);
-    LOG.info("Detector created: " + this.toString());
+    LOG.info("Detector created: " + this);
   }
 
   @Override

--- a/src/main/java/com/microsoft/dhalion/policy/PoliciesExecutor.java
+++ b/src/main/java/com/microsoft/dhalion/policy/PoliciesExecutor.java
@@ -81,7 +81,7 @@ public class PoliciesExecutor {
         Collection<Measurement> measurements = policy.executeSensors();
         measurements.stream()
             .filter(m -> m.instant().isAfter(current) || m.instant().isBefore(previous))
-            .forEach(m -> LOG.info(m.toString() + "is outside checkpoint window"));
+            .forEach(m -> LOG.info(m + "is outside checkpoint window"));
         context.measurementsTableBuilder.addAll(measurements);
 
         Collection<Symptom> symptoms = policy.executeDetectors(measurements);
@@ -113,7 +113,7 @@ public class PoliciesExecutor {
   private void identifyOutliers(Instant previous, Instant current, Collection<? extends Outcome> outcomes) {
     outcomes.stream()
         .filter(m -> m.instant().isAfter(current) || m.instant().isBefore(previous))
-        .forEach(m -> LOG.warning(m.toString() + " is outside checkpoint window"));
+        .forEach(m -> LOG.warning(m + " is outside checkpoint window"));
   }
 
   public void destroy() {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:-123981682 -->
<!-- fingerprint:1770706256 -->
<!-- fingerprint:-1338981323 -->
<!-- fingerprint:-393789298 -->
<!-- fingerprint:-793088728 -->
<!-- fingerprint:-878485145 -->
<!-- fingerprint:-42290065 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (7)
